### PR TITLE
feat: add argument device

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,8 +61,8 @@ jobs:
     strategy:
       matrix:
         command:
-          - diffused segmind/tiny-sd "an apple"
-          - diffused segmind/tiny-sd "an apple" --output apple.jpg --width=512 --height=512
+          - diffused segmind/tiny-sd apple
+          - diffused segmind/tiny-sd apple --output apple.jpg --width=512 --height=512 --device=cpu
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ diffused dreamlike-art/dreamlike-photoreal-2.0 "cinematic photo of Godzilla eati
 diffused dreamlike-art/dreamlike-photoreal-2.0 "cat eating sushi" --output=cat.jpg
 ```
 
-With short option:
+With the short option:
 
 ```sh
 diffused dreamlike-art/dreamlike-photoreal-2.0 "cat eating sushi" -o=cat.jpg
@@ -75,7 +75,7 @@ diffused dreamlike-art/dreamlike-photoreal-2.0 "cat eating sushi" -o=cat.jpg
 diffused stabilityai/stable-diffusion-xl-base-1.0 "dog in space" --width=1024
 ```
 
-With short option:
+With the short option:
 
 ```sh
 diffused stabilityai/stable-diffusion-xl-base-1.0 "dog in space" -W=1024
@@ -89,10 +89,24 @@ diffused stabilityai/stable-diffusion-xl-base-1.0 "dog in space" -W=1024
 diffused stabilityai/stable-diffusion-xl-base-1.0 "dog in space" --height=1024
 ```
 
-With short option:
+With the short option:
 
 ```sh
 diffused stabilityai/stable-diffusion-xl-base-1.0 "dog in space" -H=1024
+```
+
+### `--device`
+
+**Optional**: [Device](https://pytorch.org/docs/stable/tensor_attributes.html#torch.device) to accelerate the computation (`cpu`, `cuda`, `mps`, `xpu`, `xla`, or `meta`).
+
+```sh
+diffused stable-diffusion-v1-5/stable-diffusion-v1-5 "astronaut in the ocean, 8k" --device=cuda
+```
+
+With the short option:
+
+```sh
+diffused stable-diffusion-v1-5/stable-diffusion-v1-5 "astronaut in the ocean, 8k" -d=cuda
 ```
 
 ### `--version`
@@ -146,6 +160,8 @@ Run the script:
 ```sh
 python script.py
 ```
+
+See the [API documentation](https://ai-action.github.io/diffused/diffused/generate.html).
 
 ## License
 

--- a/src/diffused/cli.py
+++ b/src/diffused/cli.py
@@ -44,11 +44,21 @@ def main(argv: list[str] = None) -> None:
         help="image height",
     )
 
+    parser.add_argument(
+        "--device",
+        "-d",
+        help="device (cpu, cuda, mps)",
+    )
+
     args = parser.parse_args(argv)
 
     filename = args.output if args.output else f"{uuid1()}.png"
     image = generate(
-        model=args.model, prompt=args.prompt, width=args.width, height=args.height
+        model=args.model,
+        prompt=args.prompt,
+        width=args.width,
+        height=args.height,
+        device=args.device,
     )
     image.save(filename)
     print(f"🤗 {filename}")

--- a/src/diffused/generate.py
+++ b/src/diffused/generate.py
@@ -3,7 +3,11 @@ from PIL import Image
 
 
 def generate(
-    model: str, prompt: str, width: int | None = None, height: int | None = None
+    model: str,
+    prompt: str,
+    width: int | None = None,
+    height: int | None = None,
+    device: str | None = None,
 ) -> Image.Image:
     """
     Generate image with diffusion model.
@@ -13,9 +17,11 @@ def generate(
         prompt (str): Text prompt.
         width (int): Image width.
         height (int): Image height.
+        device (str): Device (cpu, cuda, mps).
 
     Returns:
         image (PIL.Image.Image): Pillow image.
     """
     pipeline = AutoPipelineForText2Image.from_pretrained(model)
+    pipeline.to(device)
     return pipeline(prompt=prompt, width=width, height=height).images[0]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,3 +112,25 @@ def test_width_height_short(
     mock_save.assert_called_once()
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
+
+
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("PIL.Image.Image.save")
+def test_device(
+    mock_from_pretrained: Mock, mock_save: Mock, capsys: pytest.LogCaptureFixture
+) -> None:
+    main(["model", "prompt", "--device", "cuda"])
+    mock_save.assert_called_once()
+    captured = capsys.readouterr()
+    assert "🤗 " in captured.out
+
+
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("PIL.Image.Image.save")
+def test_device_short(
+    mock_from_pretrained: Mock, mock_save: Mock, capsys: pytest.LogCaptureFixture
+) -> None:
+    main(["model", "prompt", "-d", "cpu"])
+    mock_save.assert_called_once()
+    captured = capsys.readouterr()
+    assert "🤗 " in captured.out

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -3,34 +3,48 @@ from unittest.mock import Mock, create_autospec, patch
 from diffused import generate
 
 
-def pipeline(prompt: str, width: int | None, height: int | None):
+def pipeline(prompt: str, width: int | None, height: int | None) -> None:
     pass  # pragma: no cover
 
 
+def pipeline_to(device: str) -> None:
+    pass  # pragma: no cover
+
+
+pipeline.to = create_autospec(pipeline_to)
 mock_pipeline = create_autospec(pipeline)
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch(
+    "diffusers.AutoPipelineForText2Image.from_pretrained", return_value=mock_pipeline
+)
 def test_generate(mock_from_pretrained: Mock) -> None:
-    mock_from_pretrained.return_value = mock_pipeline
     model = "model/test"
     prompt = "test prompt"
-    image = generate(model=model, prompt=prompt)
+    image = generate(model, prompt)
     assert isinstance(image, Mock)
     mock_from_pretrained.assert_called_once_with(model)
     mock_pipeline.assert_called_once_with(prompt=prompt, width=None, height=None)
+    mock_pipeline.to.assert_called_once_with(None)
     mock_pipeline.reset_mock()
+    mock_pipeline.to.reset_mock()
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
-def test_generate_width_height(mock_from_pretrained: Mock) -> None:
-    mock_from_pretrained.return_value = mock_pipeline
+@patch(
+    "diffusers.AutoPipelineForText2Image.from_pretrained", return_value=mock_pipeline
+)
+def test_generate_arguments(mock_from_pretrained: Mock) -> None:
     model = "model/test"
     prompt = "test prompt"
     width = 1024
     height = 1024
-    image = generate(model=model, prompt=prompt, width=width, height=height)
+    device = "cuda"
+    image = generate(
+        model=model, prompt=prompt, width=width, height=height, device=device
+    )
     assert isinstance(image, Mock)
     mock_from_pretrained.assert_called_once_with(model)
     mock_pipeline.assert_called_once_with(prompt=prompt, width=width, height=height)
+    mock_pipeline.to.assert_called_once_with(device)
     mock_pipeline.reset_mock()
+    mock_pipeline.to.reset_mock()


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add argument device

## What is the current behavior?

No way to set device

## What is the new behavior?

```sh
diffused stable-diffusion-v1-5/stable-diffusion-v1-5 "astronaut in the ocean, 8k" --device=cuda
```

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation