### PR TITLE
feat: add argument negative prompt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,8 @@ jobs:
       matrix:
         arguments:
           - apple
-          - apple --output apple.jpg --width=512 --height=512 --device=cpu
+          - apple --output apple.jpg --width=512 --height=512 --device=cpu --negative-prompt=blurry
+          - apple -o apple.png -W=256 -H=256 -d=cpu -np=dark
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -109,6 +109,20 @@ With the short option:
 diffused stable-diffusion-v1-5/stable-diffusion-v1-5 "astronaut in the ocean, 8k" -d=cuda
 ```
 
+### `--negative-prompt`
+
+**Optional**: What you don't want in the image.
+
+```sh
+diffused stabilityai/stable-diffusion-2 "photo of an apple" --negative-prompt="blurry, bright photo, red"
+```
+
+With the short option:
+
+```sh
+diffused stabilityai/stable-diffusion-2 "photo of an apple" -np="blurry, bright photo, red"
+```
+
 ### `--version`
 
 Show the program's version number and exit:

--- a/src/diffused/cli.py
+++ b/src/diffused/cli.py
@@ -27,27 +27,33 @@ def main(argv: list[str] = None) -> None:
     parser.add_argument(
         "--output",
         "-o",
-        help="output file",
+        help="generated image filename",
     )
 
     parser.add_argument(
         "--width",
         "-W",
         type=int,
-        help="image width",
+        help="image width in pixels",
     )
 
     parser.add_argument(
         "--height",
         "-H",
         type=int,
-        help="image height",
+        help="image height in pixels",
     )
 
     parser.add_argument(
         "--device",
         "-d",
-        help="device (cpu, cuda, mps)",
+        help="device to accelerate computation (cpu, cuda, mps)",
+    )
+
+    parser.add_argument(
+        "--negative-prompt",
+        "-np",
+        help="what you don't want in the image",
     )
 
     args = parser.parse_args(argv)

--- a/src/diffused/generate.py
+++ b/src/diffused/generate.py
@@ -8,6 +8,7 @@ def generate(
     width: int | None = None,
     height: int | None = None,
     device: str | None = None,
+    negative_prompt: str | None = None,
 ) -> Image.Image:
     """
     Generate image with diffusion model.
@@ -15,13 +16,16 @@ def generate(
     Args:
         model (str): Diffusion model.
         prompt (str): Text prompt.
-        width (int): Image width.
-        height (int): Image height.
-        device (str): Device (cpu, cuda, mps).
+        width (int): Image width in pixels.
+        height (int): Image height in pixels.
+        device (str): Device to accelerate computation (cpu, cuda, mps).
+        negative_prompt (str): What you don't want in the image.
 
     Returns:
         image (PIL.Image.Image): Pillow image.
     """
     pipeline = AutoPipelineForText2Image.from_pretrained(model)
     pipeline.to(device)
-    return pipeline(prompt=prompt, width=width, height=height).images[0]
+    return pipeline(
+        prompt=prompt, width=width, height=height, negative_prompt=negative_prompt
+    ).images[0]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -134,3 +134,25 @@ def test_device_short(
     mock_save.assert_called_once()
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
+
+
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("PIL.Image.Image.save")
+def test_negative_prompt(
+    mock_from_pretrained: Mock, mock_save: Mock, capsys: pytest.LogCaptureFixture
+) -> None:
+    main(["model", "prompt", "--negative-prompt", "blurry"])
+    mock_save.assert_called_once()
+    captured = capsys.readouterr()
+    assert "🤗 " in captured.out
+
+
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("PIL.Image.Image.save")
+def test_negative_prompt_short(
+    mock_from_pretrained: Mock, mock_save: Mock, capsys: pytest.LogCaptureFixture
+) -> None:
+    main(["model", "prompt", "-np", "blurry"])
+    mock_save.assert_called_once()
+    captured = capsys.readouterr()
+    assert "🤗 " in captured.out

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -3,11 +3,11 @@ from unittest.mock import Mock, create_autospec, patch
 from diffused import generate
 
 
-def pipeline(prompt: str, width: int | None, height: int | None) -> None:
+def pipeline(prompt, width, height, negative_prompt):
     pass  # pragma: no cover
 
 
-def pipeline_to(device: str) -> None:
+def pipeline_to(device):
     pass  # pragma: no cover
 
 
@@ -24,7 +24,9 @@ def test_generate(mock_from_pretrained: Mock) -> None:
     image = generate(model, prompt)
     assert isinstance(image, Mock)
     mock_from_pretrained.assert_called_once_with(model)
-    mock_pipeline.assert_called_once_with(prompt=prompt, width=None, height=None)
+    mock_pipeline.assert_called_once_with(
+        prompt=prompt, width=None, height=None, negative_prompt=None
+    )
     mock_pipeline.to.assert_called_once_with(None)
     mock_pipeline.reset_mock()
     mock_pipeline.to.reset_mock()
@@ -36,15 +38,23 @@ def test_generate(mock_from_pretrained: Mock) -> None:
 def test_generate_arguments(mock_from_pretrained: Mock) -> None:
     model = "model/test"
     prompt = "test prompt"
+    negative_prompt = "test negative prompt"
     width = 1024
     height = 1024
     device = "cuda"
     image = generate(
-        model=model, prompt=prompt, width=width, height=height, device=device
+        model=model,
+        prompt=prompt,
+        width=width,
+        height=height,
+        device=device,
+        negative_prompt=negative_prompt,
     )
     assert isinstance(image, Mock)
     mock_from_pretrained.assert_called_once_with(model)
-    mock_pipeline.assert_called_once_with(prompt=prompt, width=width, height=height)
+    mock_pipeline.assert_called_once_with(
+        prompt=prompt, width=width, height=height, negative_prompt=negative_prompt
+    )
     mock_pipeline.to.assert_called_once_with(device)
     mock_pipeline.reset_mock()
     mock_pipeline.to.reset_mock()


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add argument negative prompt

## What is the current behavior?

No way to specify what you don't want in the generated image

## What is the new behavior?

```sh
diffused stabilityai/stable-diffusion-2 "photo of an apple" --negative-prompt="blurry, bright photo, red"
```

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation