### PR TITLE
feat: add argument `guidance_scale`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,8 +62,8 @@ jobs:
       matrix:
         arguments:
           - apple
-          - apple --output apple.jpg --width=512 --height=512 --device=cpu --negative-prompt=blurry
-          - apple -o apple.png -W=256 -H=256 -d=cpu -np=dark
+          - apple --output apple.jpg --width=512 --height=512 --device=cpu --negative-prompt=blurry --guidance-scale=7.5
+          - apple -o apple.png -W 256 -H 256 -d cpu -np dark -gs 7.5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ With the short option:
 diffused stabilityai/stable-diffusion-2 "photo of an apple" -np="blurry, bright photo, red"
 ```
 
+### `--guidance-scale`
+
+**Optional**: How much the prompt influences image generation. A lower value leads to more deviation and creativity, whereas a higher value follows the prompt to a tee.
+
+```sh
+diffused stable-diffusion-v1-5/stable-diffusion-v1-5 "astronaut in a jungle" --guidance-scale=7.5
+```
+
+With the short option:
+
+```sh
+diffused stable-diffusion-v1-5/stable-diffusion-v1-5 "astronaut in a jungle" -gs=7.5
+```
+
 ### `--version`
 
 Show the program's version number and exit:

--- a/src/diffused/cli.py
+++ b/src/diffused/cli.py
@@ -56,6 +56,13 @@ def main(argv: list[str] = None) -> None:
         help="what to exclude from the generated image",
     )
 
+    parser.add_argument(
+        "--guidance-scale",
+        "-gs",
+        help="how much the prompt influences image generation",
+        type=float,
+    )
+
     args = parser.parse_args(argv)
 
     image = generate(
@@ -65,6 +72,7 @@ def main(argv: list[str] = None) -> None:
         height=args.height,
         device=args.device,
         negative_prompt=args.negative_prompt,
+        guidance_scale=args.guidance_scale,
     )
 
     filename = args.output if args.output else f"{uuid1()}.png"

--- a/src/diffused/generate.py
+++ b/src/diffused/generate.py
@@ -9,6 +9,7 @@ def generate(
     height: int | None = None,
     device: str | None = None,
     negative_prompt: str | None = None,
+    guidance_scale: float | None = None,
 ) -> Image.Image:
     """
     Generate image with diffusion model.
@@ -20,12 +21,28 @@ def generate(
         height (int): Generated image height in pixels.
         device (str): Device to accelerate computation (cpu, cuda, mps).
         negative_prompt (str): What to exclude from the generated image.
+        guidance_scale (float): How much the prompt influences image generation.
 
     Returns:
         image (PIL.Image.Image): Pillow image.
     """
     pipeline = AutoPipelineForText2Image.from_pretrained(model)
     pipeline.to(device)
-    return pipeline(
-        prompt=prompt, width=width, height=height, negative_prompt=negative_prompt
-    ).images[0]
+
+    if guidance_scale:
+        images = pipeline(
+            prompt=prompt,
+            width=width,
+            height=height,
+            negative_prompt=negative_prompt,
+            guidance_scale=guidance_scale,
+        ).images
+    else:
+        images = pipeline(
+            prompt=prompt,
+            width=width,
+            height=height,
+            negative_prompt=negative_prompt,
+        ).images
+
+    return images[0]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -156,3 +156,25 @@ def test_negative_prompt_short(
     mock_save.assert_called_once()
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
+
+
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("PIL.Image.Image.save")
+def test_guidance_scale(
+    mock_from_pretrained: Mock, mock_save: Mock, capsys: pytest.LogCaptureFixture
+) -> None:
+    main(["model", "prompt", "--guidance-scale", "7.5"])
+    mock_save.assert_called_once()
+    captured = capsys.readouterr()
+    assert "🤗 " in captured.out
+
+
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("PIL.Image.Image.save")
+def test_guidance_scale_short(
+    mock_from_pretrained: Mock, mock_save: Mock, capsys: pytest.LogCaptureFixture
+) -> None:
+    main(["model", "prompt", "-gs", "7.5"])
+    mock_save.assert_called_once()
+    captured = capsys.readouterr()
+    assert "🤗 " in captured.out

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, create_autospec, patch
 from diffused import generate
 
 
-def pipeline(prompt, width, height, negative_prompt):
+def pipeline(prompt, width, height, negative_prompt, guidance_scale=None):
     pass  # pragma: no cover
 
 
@@ -24,9 +24,14 @@ def test_generate(mock_from_pretrained: Mock) -> None:
     image = generate(model, prompt)
     assert isinstance(image, Mock)
     mock_from_pretrained.assert_called_once_with(model)
+
     mock_pipeline.assert_called_once_with(
-        prompt=prompt, width=None, height=None, negative_prompt=None
+        prompt=prompt,
+        width=None,
+        height=None,
+        negative_prompt=None,
     )
+
     mock_pipeline.to.assert_called_once_with(None)
     mock_pipeline.reset_mock()
     mock_pipeline.to.reset_mock()
@@ -42,6 +47,8 @@ def test_generate_arguments(mock_from_pretrained: Mock) -> None:
     width = 1024
     height = 1024
     device = "cuda"
+    guidance_scale = 7.5
+
     image = generate(
         model=model,
         prompt=prompt,
@@ -49,11 +56,17 @@ def test_generate_arguments(mock_from_pretrained: Mock) -> None:
         height=height,
         device=device,
         negative_prompt=negative_prompt,
+        guidance_scale=guidance_scale,
     )
+
     assert isinstance(image, Mock)
     mock_from_pretrained.assert_called_once_with(model)
     mock_pipeline.assert_called_once_with(
-        prompt=prompt, width=width, height=height, negative_prompt=negative_prompt
+        prompt=prompt,
+        width=width,
+        height=height,
+        negative_prompt=negative_prompt,
+        guidance_scale=guidance_scale,
     )
     mock_pipeline.to.assert_called_once_with(device)
     mock_pipeline.reset_mock()


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add argument `guidance_scale`

https://huggingface.co/docs/diffusers/en/using-diffusers/conditional_image_generation#guidance-scale

## What is the current behavior?

No way to control how much the prompt influences image generation.

## What is the new behavior?

```sh
diffused stable-diffusion-v1-5/stable-diffusion-v1-5 "astronaut in a jungle" --guidance-scale=7.5
```

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation