### PR TITLE
feat: add `num_inference_steps`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,8 +62,8 @@ jobs:
       matrix:
         arguments:
           - apple
-          - apple --output apple.jpg --width=512 --height=512 --device=cpu --negative-prompt=blurry --guidance-scale=7.5
-          - apple -o apple.png -W 256 -H 256 -d cpu -np dark -gs 7.5
+          - apple --output apple.jpg --width=512 --height=512 --device=cpu --negative-prompt=blurry --guidance-scale=7.5 --inference-steps=15
+          - apple -o apple.png -W 256 -H 256 -d cpu -np dark -gs 7.5 -is 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -137,6 +137,20 @@ With the short option:
 diffused stable-diffusion-v1-5/stable-diffusion-v1-5 "astronaut in a jungle" -gs=7.5
 ```
 
+### `--inference-steps`
+
+**Optional**: Number of diffusion steps used during image generation. The more steps you use, the higher the quality, but the generation time will increase.
+
+```sh
+diffused CompVis/stable-diffusion-v1-4 "astronaut rides horse" --inference-steps=50
+```
+
+With the short option:
+
+```sh
+diffused CompVis/stable-diffusion-v1-4 "astronaut rides horse" -is=50
+```
+
 ### `--version`
 
 Show the program's version number and exit:

--- a/src/diffused/cli.py
+++ b/src/diffused/cli.py
@@ -63,6 +63,13 @@ def main(argv: list[str] = None) -> None:
         type=float,
     )
 
+    parser.add_argument(
+        "--inference-steps",
+        "-is",
+        help="number of diffusion steps",
+        type=int,
+    )
+
     args = parser.parse_args(argv)
     generate_args = {
         "model": args.model,
@@ -72,6 +79,7 @@ def main(argv: list[str] = None) -> None:
         "device": args.device,
         "negative_prompt": args.negative_prompt,
         "guidance_scale": args.guidance_scale,
+        "num_inference_steps": args.inference_steps,
     }
 
     filename = args.output if args.output else f"{uuid1()}.png"

--- a/src/diffused/generate.py
+++ b/src/diffused/generate.py
@@ -12,6 +12,7 @@ class Generate(TypedDict):
     device: NotRequired[str]
     negative_prompt: NotRequired[str]
     guidance_scale: NotRequired[float]
+    num_inference_steps: NotRequired[int]
 
 
 def generate(**kwargs: Unpack[Generate]) -> Image.Image:
@@ -26,6 +27,7 @@ def generate(**kwargs: Unpack[Generate]) -> Image.Image:
         device (str): Device to accelerate computation (cpu, cuda, mps).
         negative_prompt (str): What to exclude from the generated image.
         guidance_scale (float): How much the prompt influences image generation.
+        num_inference_steps (int): Number of diffusion steps used for generation.
 
     Returns:
         image (PIL.Image.Image): Pillow image.
@@ -43,9 +45,11 @@ def generate(**kwargs: Unpack[Generate]) -> Image.Image:
         "negative_prompt": kwargs.get("negative_prompt"),
     }
 
-    guidance_scale = kwargs.get("guidance_scale")
-    if guidance_scale:
-        pipeline_args["guidance_scale"] = guidance_scale
+    if kwargs.get("guidance_scale"):
+        pipeline_args["guidance_scale"] = kwargs.get("guidance_scale")
+
+    if kwargs.get("num_inference_steps"):
+        pipeline_args["num_inference_steps"] = kwargs.get("num_inference_steps")
 
     images = pipeline(**pipeline_args).images
     return images[0]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -178,3 +178,25 @@ def test_guidance_scale_short(
     mock_save.assert_called_once()
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
+
+
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("PIL.Image.Image.save")
+def test_inference_steps(
+    mock_from_pretrained: Mock, mock_save: Mock, capsys: pytest.LogCaptureFixture
+) -> None:
+    main(["model", "prompt", "--inference-steps", "50"])
+    mock_save.assert_called_once()
+    captured = capsys.readouterr()
+    assert "🤗 " in captured.out
+
+
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("PIL.Image.Image.save")
+def test_inference_steps_short(
+    mock_from_pretrained: Mock, mock_save: Mock, capsys: pytest.LogCaptureFixture
+) -> None:
+    main(["model", "prompt", "-is", "15"])
+    mock_save.assert_called_once()
+    captured = capsys.readouterr()
+    assert "🤗 " in captured.out

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -47,6 +47,7 @@ def test_generate_arguments(mock_from_pretrained: Mock) -> None:
         "width": 1024,
         "height": 1024,
         "guidance_scale": 7.5,
+        "num_inference_steps": 50,
     }
 
     image = generate(model=model, device=device, **pipeline_args)


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add `num_inference_steps`

## What is the current behavior?

No way to set the number of inference steps

## What is the new behavior?

```sh
diffused CompVis/stable-diffusion-v1-4 "astronaut rides horse" --inference-steps=50
```

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation