### PR TITLE
feat: allow more than one image to be generated with `number`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,9 +72,9 @@ jobs:
           - task: image-to-image
             args: astro -i tests/img2img.png --no-safetensors
           - task: inpainting
-            args: cat --image tests/inpaint.png --mask-image tests/inpaint_mask.png --strength 0.5 --number 2
+            args: cat --image tests/inpaint.png --mask-image tests/inpaint_mask.png --strength 0.3 --number 2
           - task: inpainting
-            args: cat -i tests/inpaint.png -mi tests/inpaint_mask.png --no-safetensors -s 0.5 -n 2
+            args: cat -i tests/inpaint.png -mi tests/inpaint_mask.png --no-safetensors -s 0.3 -n 2
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,17 +64,17 @@ jobs:
           - task: text-to-image
             args: apple
           - task: text-to-image
-            args: apple --output apple.jpg --width=512 --height=512 --device=cpu --negative-prompt=blurry --inference-steps=25 --seed=0
+            args: apple --output apple.jpg --width=512 --height=512 --device=cpu --negative-prompt=blurry --inference-steps=25 --seed=0 --number=2
           - task: text-to-image
-            args: apple -o apple.png -W 256 -H 256 -d cpu -np dark -gs 9.5 -is 75 -S -1
+            args: apple -o apple.png -W 256 -H 256 -d cpu -np dark -gs 9.5 -is 75 -S -1 -n 2
           - task: image-to-image
             args: tiger --image=https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/cat.png --inference-steps=10
           - task: image-to-image
             args: astro -i tests/img2img.png --no-safetensors
           - task: inpainting
-            args: cat --image tests/inpaint.png --mask-image tests/inpaint_mask.png --strength 0.8
+            args: cat --image tests/inpaint.png --mask-image tests/inpaint_mask.png --strength 0.5 --number 2
           - task: inpainting
-            args: cat -i tests/inpaint.png -mi tests/inpaint_mask.png --no-safetensors -s 0.8
+            args: cat -i tests/inpaint.png -mi tests/inpaint_mask.png --no-safetensors -s 0.5 -n 2
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -145,6 +145,20 @@ With the short option:
 diffused stabilityai/stable-diffusion-xl-base-1.0 "dog in space" -H=1024
 ```
 
+### `--number`
+
+**Optional** (*int*): The number of output images. Defaults to 1.
+
+```sh
+diffused segmind/tiny-sd apple --number=2
+```
+
+With the short option:
+
+```sh
+diffused segmind/tiny-sd apple -n=2
+```
+
 ### `--guidance-scale`
 
 **Optional** (*int*): How much the prompt influences the output image. A lower value leads to more deviation and creativity, whereas a higher value follows the prompt to a tee.
@@ -265,8 +279,8 @@ Generate an image with a [model](https://huggingface.co/segmind/tiny-sd) and a p
 # script.py
 from diffused import generate
 
-image = generate(model="segmind/tiny-sd", prompt="apple")
-image.save("apple.png")
+images = generate(model="segmind/tiny-sd", prompt="apple")
+images[0].save("apple.png")
 ```
 
 Run the script:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ maintainers = [
 ]
 readme = "README.md"
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Education",
     "Intended Audience :: Science/Research",

--- a/src/diffused/cli.py
+++ b/src/diffused/cli.py
@@ -1,4 +1,6 @@
 import argparse
+import math
+import os
 from uuid import uuid1
 
 from diffused import __version__, generate
@@ -63,6 +65,14 @@ def main(argv: list[str] = None) -> None:
     )
 
     parser.add_argument(
+        "--number",
+        "-n",
+        default=1,
+        help="number of output images [default: 1]",
+        type=int,
+    )
+
+    parser.add_argument(
         "--guidance-scale",
         "-gs",
         help="how much the prompt influences output image",
@@ -112,6 +122,7 @@ def main(argv: list[str] = None) -> None:
         "mask_image": args.mask_image,
         "model": args.model,
         "negative_prompt": args.negative_prompt,
+        "num_images_per_prompt": args.number,
         "num_inference_steps": args.inference_steps,
         "prompt": args.prompt,
         "seed": args.seed,
@@ -120,10 +131,24 @@ def main(argv: list[str] = None) -> None:
         "width": args.width,
     }
 
-    filename = args.output if args.output else f"{uuid1()}.png"
-    image = generate(**generate_args)
-    image.save(filename)
-    print(f"🤗 {filename}")
+    images = generate(**generate_args)
+    images_length = len(images)
+
+    for index, image in enumerate(images):
+        if args.output:
+            if images_length == 1:
+                filename = args.output
+            else:
+                basename, extension = os.path.splitext(args.output)
+                idx = str(index + 1).rjust(
+                    math.floor(math.log10(images_length)) + 1, "0"
+                )
+                filename = f"{basename}{idx}{extension}"
+        else:
+            filename = f"{uuid1()}.png"
+
+        image.save(filename)
+        print(f"🤗 {filename}")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/diffused/generate.py
+++ b/src/diffused/generate.py
@@ -13,6 +13,7 @@ class Generate(TypedDict):
     mask_image: NotRequired[str]
     width: NotRequired[int]
     height: NotRequired[int]
+    num_images_per_prompt: NotRequired[int]
     guidance_scale: NotRequired[float]
     num_inference_steps: NotRequired[int]
     strength: NotRequired[float]
@@ -21,7 +22,7 @@ class Generate(TypedDict):
     use_safetensors: NotRequired[bool]
 
 
-def generate(**kwargs: Unpack[Generate]) -> Image.Image:
+def generate(**kwargs: Unpack[Generate]) -> list[Image.Image]:
     """
     Generate image with diffusion model.
 
@@ -33,6 +34,7 @@ def generate(**kwargs: Unpack[Generate]) -> Image.Image:
         mask_image (str): Mask image path or URL.
         width (int): Generated image width in pixels.
         height (int): Generated image height in pixels.
+        num_images_per_prompt (int): Number of images per prompt.
         guidance_scale (float): How much the prompt influences image generation.
         num_inference_steps (int): Number of diffusion steps used for generation.
         strength (float): How much noise is added to the input image.
@@ -41,13 +43,14 @@ def generate(**kwargs: Unpack[Generate]) -> Image.Image:
         use_safetensors (bool): Whether to load safetensors.
 
     Returns:
-        image (PIL.Image.Image): Pillow image.
+        images (list[PIL.Image.Image]): Pillow images.
     """
     pipeline_args = {
         "prompt": kwargs.get("prompt"),
+        "negative_prompt": kwargs.get("negative_prompt"),
         "width": kwargs.get("width"),
         "height": kwargs.get("height"),
-        "negative_prompt": kwargs.get("negative_prompt"),
+        "num_images_per_prompt": kwargs.get("num_images_per_prompt", 1),
         "use_safetensors": kwargs.get("use_safetensors", True),
     }
 
@@ -86,4 +89,4 @@ def generate(**kwargs: Unpack[Generate]) -> Image.Image:
         pipeline_args["generator"] = torch.Generator(device=device).manual_seed(seed)
 
     images = pipeline(**pipeline_args).images
-    return images[0]
+    return images

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ class Pipeline:
 
     def __init__(self, **kwargs):
         Pipeline.mock(**kwargs)
-        Pipeline.images = [Mock()] * kwargs.get("num_images_per_prompt")
+        Pipeline.images = [Mock() for _ in range(kwargs.get("num_images_per_prompt"))]
 
     @staticmethod
     def reset_mock():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+from unittest.mock import Mock
+
+model = "test/model"
+device = "cuda"
+prompt = "prompt"
+image = "image.png"
+mask_image = "mask.png"
+
+
+class Pipeline:
+    to = Mock()
+    mock = Mock()
+
+    def __init__(self, **kwargs):
+        Pipeline.mock(**kwargs)
+        Pipeline.images = [Mock()] * kwargs.get("num_images_per_prompt")
+
+    @staticmethod
+    def reset_mock():
+        Pipeline.mock.reset_mock()
+        Pipeline.to.reset_mock()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -121,7 +121,8 @@ def test_number_short(
     mock_from_pretrained.assert_called_once_with(model)
     captured = capsys.readouterr()
     assert len(Pipeline.images) == 10
-    assert Pipeline.images[0].save.call_count == 10
+    for img in Pipeline.images:
+        img.save.assert_called_once()
     assert "🤗 test01.jpg" in captured.out
     assert "🤗 test10.jpg" in captured.out
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,9 +6,7 @@ import pytest
 from diffused import __version__
 from diffused.cli import main
 
-model = "test/model"
-image = "image.png"
-mask_image = "mask.png"
+from .conftest import Pipeline, device, image, mask_image, model, prompt
 
 
 def test_version(capsys: pytest.LogCaptureFixture) -> None:
@@ -49,18 +47,29 @@ def test_no_arguments(capsys: pytest.LogCaptureFixture) -> None:
 
 def test_invalid_argument(capsys: pytest.LogCaptureFixture) -> None:
     with pytest.raises(SystemExit) as exception:
-        main([model, "prompt", "--invalid"])
+        main([model, prompt, "--invalid"])
     captured = capsys.readouterr()
     assert exception.type is SystemExit
     assert "error: unrecognized arguments: --invalid" in captured.err
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_generate_image(
     mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture
 ) -> None:
-    main([model, "prompt"])
+    Pipeline.reset_mock()
+    main([model, prompt])
     mock_from_pretrained.assert_called_once_with(model)
+    Pipeline.mock.assert_called_once_with(
+        prompt=prompt,
+        negative_prompt=None,
+        width=None,
+        height=None,
+        num_images_per_prompt=1,
+        use_safetensors=True,
+    )
+    assert len(Pipeline.images) == 1
+    Pipeline.images[0].save.assert_called_once()
     captured = capsys.readouterr()
     assert (
         re.match(
@@ -71,184 +80,231 @@ def test_generate_image(
     )
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_output(mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture) -> None:
-    main([model, "prompt", "--output", image])
+    Pipeline.reset_mock()
+    main([model, prompt, "--output", image])
     mock_from_pretrained.assert_called_once_with(model)
+    assert len(Pipeline.images) == 1
+    Pipeline.images[0].save.assert_called_once_with(image)
     captured = capsys.readouterr()
     assert captured.out == f"🤗 {image}\n"
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_output_short(
     mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture
 ) -> None:
-    main([model, "prompt", "-o", image])
+    Pipeline.reset_mock()
+    main([model, prompt, "-o", image])
     mock_from_pretrained.assert_called_once_with(model)
     captured = capsys.readouterr()
     assert captured.out == f"🤗 {image}\n"
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
+def test_number(mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture) -> None:
+    Pipeline.reset_mock()
+    main([model, prompt, "-o", "test.jpg", "-n", "2"])
+    mock_from_pretrained.assert_called_once_with(model)
+    assert len(Pipeline.images) == 2
+    captured = capsys.readouterr()
+    assert captured.out == "🤗 test1.jpg\n🤗 test2.jpg\n"
+
+
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
+def test_number_short(
+    mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture
+) -> None:
+    Pipeline.reset_mock()
+    main([model, prompt, "-o", "test.jpg", "-n", "10"])
+    mock_from_pretrained.assert_called_once_with(model)
+    captured = capsys.readouterr()
+    assert len(Pipeline.images) == 10
+    assert Pipeline.images[0].save.call_count == 10
+    assert "🤗 test01.jpg" in captured.out
+    assert "🤗 test10.jpg" in captured.out
+
+
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_width_height(
     mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture
 ) -> None:
-    main([model, "prompt", "--width", "1024", "--height", "1024"])
+    Pipeline.reset_mock()
+    main([model, prompt, "--width", "1024", "--height", "1024"])
     mock_from_pretrained.assert_called_once_with(model)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_width_height_short(
     mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture
 ) -> None:
-    main([model, "prompt", "-W", "1024", "-H", "1024"])
+    Pipeline.reset_mock()
+    main([model, prompt, "-W", "1024", "-H", "1024"])
     mock_from_pretrained.assert_called_once_with(model)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_device(mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture) -> None:
-    main([model, "prompt", "--device", "cuda"])
+    Pipeline.reset_mock()
+    main([model, prompt, "--device", device])
     mock_from_pretrained.assert_called_once_with(model)
+    Pipeline.to.assert_called_once_with(device)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_device_short(
     mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture
 ) -> None:
-    main([model, "prompt", "-d", "cpu"])
+    Pipeline.reset_mock()
+    main([model, prompt, "-d", "cpu"])
     mock_from_pretrained.assert_called_once_with(model)
+    Pipeline.to.assert_called_once_with("cpu")
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_negative_prompt(
     mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture
 ) -> None:
-    main([model, "prompt", "--negative-prompt", "blurry"])
+    Pipeline.reset_mock()
+    main([model, prompt, "--negative-prompt", "blurry"])
     mock_from_pretrained.assert_called_once_with(model)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_negative_prompt_short(
     mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture
 ) -> None:
-    main([model, "prompt", "-np", "blurry"])
+    Pipeline.reset_mock()
+    main([model, prompt, "-np", "blurry"])
     mock_from_pretrained.assert_called_once_with(model)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_guidance_scale(
     mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture
 ) -> None:
-    main([model, "prompt", "--guidance-scale", "7.5"])
+    Pipeline.reset_mock()
+    main([model, prompt, "--guidance-scale", "7.5"])
     mock_from_pretrained.assert_called_once_with(model)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_guidance_scale_short(
     mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture
 ) -> None:
-    main([model, "prompt", "-gs", "7.5"])
+    Pipeline.reset_mock()
+    main([model, prompt, "-gs", "7.5"])
     mock_from_pretrained.assert_called_once_with(model)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_inference_steps(
     mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture
 ) -> None:
-    main([model, "prompt", "--inference-steps", "50"])
+    Pipeline.reset_mock()
+    main([model, prompt, "--inference-steps", "50"])
     mock_from_pretrained.assert_called_once_with(model)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_inference_steps_short(
     mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture
 ) -> None:
-    main([model, "prompt", "-is", "15"])
+    Pipeline.reset_mock()
+    main([model, prompt, "-is", "15"])
     mock_from_pretrained.assert_called_once_with(model)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_strength(mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture) -> None:
-    main([model, "prompt", "--strength", "0.5"])
+    Pipeline.reset_mock()
+    main([model, prompt, "--strength", "0.5"])
     mock_from_pretrained.assert_called_once_with(model)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_strength_short(
     mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture
 ) -> None:
-    main([model, "prompt", "-s", "0.5"])
+    Pipeline.reset_mock()
+    main([model, prompt, "-s", "0.5"])
     mock_from_pretrained.assert_called_once_with(model)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_seed(mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture) -> None:
-    main([model, "prompt", "--seed", "0"])
+    Pipeline.reset_mock()
+    main([model, prompt, "--seed", "0"])
     mock_from_pretrained.assert_called_once_with(model)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_seed_short(
     mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture
 ) -> None:
-    main([model, "prompt", "-S", "-1"])
+    Pipeline.reset_mock()
+    main([model, prompt, "-S", "-1"])
     mock_from_pretrained.assert_called_once_with(model)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_safetensors(
     mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture
 ) -> None:
-    main([model, "prompt", "--safetensors"])
+    Pipeline.reset_mock()
+    main([model, prompt, "--safetensors"])
     mock_from_pretrained.assert_called_once_with(model)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
 
-@patch("diffusers.AutoPipelineForText2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_no_safetensors(
     mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture
 ) -> None:
-    main([model, "prompt", "--no-safetensors"])
+    Pipeline.reset_mock()
+    main([model, prompt, "--no-safetensors"])
     mock_from_pretrained.assert_called_once_with(model)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
 
 @patch("diffusers.utils.load_image")
-@patch("diffusers.AutoPipelineForImage2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForImage2Image.from_pretrained", return_value=Pipeline)
 def test_image(
     mock_from_pretrained: Mock, mock_load_image: Mock, capsys: pytest.LogCaptureFixture
 ) -> None:
-    main([model, "prompt", "--image", image])
+    Pipeline.reset_mock()
+    main([model, prompt, "--image", image])
     mock_from_pretrained.assert_called_once_with(model)
     mock_load_image.assert_called_once_with(image)
     captured = capsys.readouterr()
@@ -256,11 +312,12 @@ def test_image(
 
 
 @patch("diffusers.utils.load_image")
-@patch("diffusers.AutoPipelineForImage2Image.from_pretrained")
+@patch("diffusers.AutoPipelineForImage2Image.from_pretrained", return_value=Pipeline)
 def test_image_short(
     mock_from_pretrained: Mock, mock_load_image: Mock, capsys: pytest.LogCaptureFixture
 ) -> None:
-    main([model, "prompt", "-i", image])
+    Pipeline.reset_mock()
+    main([model, prompt, "-i", image])
     mock_from_pretrained.assert_called_once_with(model)
     mock_load_image.assert_called_once_with(image)
     captured = capsys.readouterr()
@@ -268,11 +325,12 @@ def test_image_short(
 
 
 @patch("diffusers.utils.load_image")
-@patch("diffusers.AutoPipelineForInpainting.from_pretrained")
+@patch("diffusers.AutoPipelineForInpainting.from_pretrained", return_value=Pipeline)
 def test_mask_image(
     mock_from_pretrained: Mock, mock_load_image: Mock, capsys: pytest.LogCaptureFixture
 ) -> None:
-    main([model, "prompt", "--image", image, "--mask-image", mask_image])
+    Pipeline.reset_mock()
+    main([model, prompt, "--image", image, "--mask-image", mask_image])
     mock_from_pretrained.assert_called_once_with(model)
     mock_load_image.assert_has_calls([call(image), call(mask_image)])
     captured = capsys.readouterr()
@@ -280,11 +338,12 @@ def test_mask_image(
 
 
 @patch("diffusers.utils.load_image")
-@patch("diffusers.AutoPipelineForInpainting.from_pretrained")
+@patch("diffusers.AutoPipelineForInpainting.from_pretrained", return_value=Pipeline)
 def test_mask_image_short(
     mock_from_pretrained: Mock, mock_load_image: Mock, capsys: pytest.LogCaptureFixture
 ) -> None:
-    main([model, "prompt", "-i", image, "-mi", mask_image])
+    Pipeline.reset_mock()
+    main([model, prompt, "-i", image, "-mi", mask_image])
     mock_from_pretrained.assert_called_once_with(model)
     mock_load_image.assert_has_calls([call(image), call(mask_image)])
     captured = capsys.readouterr()

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,164 +1,146 @@
-from unittest.mock import ANY, Mock, call, create_autospec, patch
+from unittest.mock import ANY, Mock, call, patch
 
 from diffused import generate
 
-
-def pipeline(**kwargs):
-    pass  # pragma: no cover
+from .conftest import Pipeline, device, image, mask_image, model, prompt
 
 
-def pipeline_to(*args):
-    pass  # pragma: no cover
-
-
-pipeline.to = create_autospec(pipeline_to)
-mock_pipeline = create_autospec(pipeline)
-
-model = "test/model"
-device = "cuda"
-prompt = "prompt"
-image = "image.png"
-mask_image = "mask.png"
-
-
-@patch(
-    "diffusers.AutoPipelineForText2Image.from_pretrained", return_value=mock_pipeline
-)
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_text_to_image(mock_from_pretrained: Mock) -> None:
     pipeline_args = {
         "prompt": prompt,
+        "negative_prompt": None,
         "width": None,
         "height": None,
-        "negative_prompt": None,
+        "num_images_per_prompt": 1,
         "use_safetensors": True,
     }
-    image = generate(model=model, prompt=prompt)
-    assert isinstance(image, Mock)
+    Pipeline.reset_mock()
+    images = generate(model=model, prompt=prompt)
+    assert len(images) == 1
+    assert isinstance(images[0], Mock)
     mock_from_pretrained.assert_called_once_with(model)
-    mock_pipeline.assert_called_once_with(**pipeline_args)
-    mock_pipeline.to.assert_not_called()
-    mock_pipeline.reset_mock()
+    Pipeline.mock.assert_called_once_with(**pipeline_args)
+    Pipeline.to.assert_not_called()
 
 
-@patch(
-    "diffusers.AutoPipelineForText2Image.from_pretrained", return_value=mock_pipeline
-)
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_text_to_image_with_arguments(mock_from_pretrained: Mock) -> None:
     pipeline_args = {
         "prompt": prompt,
         "negative_prompt": "test negative prompt",
         "width": 1024,
         "height": 1024,
+        "num_images_per_prompt": 2,
         "guidance_scale": 7.5,
         "num_inference_steps": 50,
         "strength": 0.5,
         "use_safetensors": False,
     }
-    image = generate(model=model, device=device, **pipeline_args)
-    assert isinstance(image, Mock)
+    Pipeline.reset_mock()
+    images = generate(model=model, device=device, **pipeline_args)
+    assert len(images) == 2
+    assert isinstance(images[0], Mock)
     mock_from_pretrained.assert_called_once_with(model)
-    mock_pipeline.assert_called_once_with(**pipeline_args)
-    mock_pipeline.to.assert_called_once_with(device)
-    mock_pipeline.reset_mock()
-    mock_pipeline.to.reset_mock()
+    Pipeline.mock.assert_called_once_with(**pipeline_args)
+    Pipeline.to.assert_called_once_with(device)
 
 
 @patch("torch.Generator")
-@patch(
-    "diffusers.AutoPipelineForText2Image.from_pretrained", return_value=mock_pipeline
-)
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_text_to_image_with_seed(
     mock_from_pretrained: Mock, mock_generator: Mock
 ) -> None:
     seed = -1
     pipeline_args = {
         "prompt": prompt,
+        "negative_prompt": None,
         "width": None,
         "height": None,
-        "negative_prompt": None,
+        "num_images_per_prompt": 1,
         "use_safetensors": True,
     }
-    image = generate(model=model, device=device, seed=seed, **pipeline_args)
-    assert isinstance(image, Mock)
+    Pipeline.reset_mock()
+    images = generate(model=model, device=device, seed=seed, **pipeline_args)
+    assert len(images) == 1
+    assert isinstance(images[0], Mock)
     mock_from_pretrained.assert_called_once_with(model)
     mock_generator.assert_called_once_with(device=device)
     pipeline_args["generator"] = ANY
-    mock_pipeline.assert_called_once_with(**pipeline_args)
-    mock_pipeline.to.assert_called_once_with(device)
-    mock_pipeline.reset_mock()
-    mock_pipeline.to.reset_mock()
+    Pipeline.mock.assert_called_once_with(**pipeline_args)
+    Pipeline.to.assert_called_once_with(device)
 
 
 @patch("torch.Generator")
-@patch(
-    "diffusers.AutoPipelineForText2Image.from_pretrained", return_value=mock_pipeline
-)
+@patch("diffusers.AutoPipelineForText2Image.from_pretrained", return_value=Pipeline)
 def test_arguments_with_zero_values(
     mock_from_pretrained: Mock, mock_generator: Mock
 ) -> None:
     seed = 0
     pipeline_args = {
         "prompt": prompt,
+        "negative_prompt": None,
         "width": None,
         "height": None,
-        "negative_prompt": None,
-        "use_safetensors": True,
+        "num_images_per_prompt": 1,
         "guidance_scale": 0,
         "num_inference_steps": 0,
         "strength": 0,
+        "use_safetensors": True,
     }
-    image = generate(model=model, seed=seed, **pipeline_args)
-    assert isinstance(image, Mock)
+    Pipeline.reset_mock()
+    images = generate(model=model, seed=seed, **pipeline_args)
+    assert len(images) == 1
+    assert isinstance(images[0], Mock)
     mock_from_pretrained.assert_called_once_with(model)
     mock_generator.assert_called_once_with(device=None)
     pipeline_args["generator"] = ANY
-    mock_pipeline.assert_called_once_with(**pipeline_args)
-    mock_pipeline.to.assert_not_called()
-    mock_pipeline.reset_mock()
+    Pipeline.mock.assert_called_once_with(**pipeline_args)
+    Pipeline.to.assert_not_called()
 
 
 @patch("diffusers.utils.load_image")
-@patch(
-    "diffusers.AutoPipelineForImage2Image.from_pretrained", return_value=mock_pipeline
-)
+@patch("diffusers.AutoPipelineForImage2Image.from_pretrained", return_value=Pipeline)
 def test_image_to_image(mock_from_pretrained: Mock, mock_load_image: Mock) -> None:
     pipeline_args = {
         "prompt": prompt,
+        "negative_prompt": None,
         "image": mock_load_image(),
         "width": None,
         "height": None,
-        "negative_prompt": None,
+        "num_images_per_prompt": 1,
         "use_safetensors": True,
     }
     mock_load_image.reset_mock()
-    output = generate(model=model, prompt=prompt, image=image)
-    assert isinstance(output, Mock)
+    Pipeline.reset_mock()
+    images = generate(model=model, prompt=prompt, image=image)
+    assert len(images) == 1
+    assert isinstance(images[0], Mock)
     mock_from_pretrained.assert_called_once_with(model)
     mock_load_image.assert_called_once_with(image)
-    mock_pipeline.assert_called_once_with(**pipeline_args)
-    mock_pipeline.to.assert_not_called()
-    mock_pipeline.reset_mock()
+    Pipeline.mock.assert_called_once_with(**pipeline_args)
+    Pipeline.to.assert_not_called()
 
 
 @patch("diffusers.utils.load_image")
-@patch(
-    "diffusers.AutoPipelineForInpainting.from_pretrained", return_value=mock_pipeline
-)
+@patch("diffusers.AutoPipelineForInpainting.from_pretrained", return_value=Pipeline)
 def test_inpainting(mock_from_pretrained: Mock, mock_load_image: Mock) -> None:
     pipeline_args = {
         "prompt": prompt,
+        "negative_prompt": None,
         "image": mock_load_image(),
         "mask_image": mock_load_image(),
         "width": None,
         "height": None,
-        "negative_prompt": None,
+        "num_images_per_prompt": 1,
         "use_safetensors": True,
     }
     mock_load_image.reset_mock()
-    output = generate(model=model, prompt=prompt, image=image, mask_image=mask_image)
-    assert isinstance(output, Mock)
+    Pipeline.reset_mock()
+    images = generate(model=model, prompt=prompt, image=image, mask_image=mask_image)
+    assert len(images) == 1
+    assert isinstance(images[0], Mock)
     mock_from_pretrained.assert_called_once_with(model)
     mock_load_image.assert_has_calls([call(image), call(mask_image)])
-    mock_pipeline.assert_called_once_with(**pipeline_args)
-    mock_pipeline.to.assert_not_called()
-    mock_pipeline.reset_mock()
+    Pipeline.mock.assert_called_once_with(**pipeline_args)
+    Pipeline.to.assert_not_called()


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: allow more than one image to be generated with `number`

**BREAKING CHANGE:** `generate` returns a list of images instead of one

## What is the current behavior?

Only 1 image is generated

## What is the new behavior?

`--number` allows more than 1 image to be generated:

```sh
diffused segmind/tiny-sd apple --number=2
```

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation