### PR TITLE
build: refactor from pip to uv

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,28 +23,22 @@ Install [Python](https://www.python.org/):
 brew install python
 ```
 
-Create the virtual environment:
+Install [uv](https://docs.astral.sh/uv/):
 
 ```sh
-python3 -m venv .venv
-```
-
-Activate the virtual environment:
-
-```sh
-source .venv/bin/activate
+brew install uv
 ```
 
 Install the dependencies:
 
 ```sh
-pip install -e '.[lint]'
+uv sync --all-groups
 ```
 
 Install pre-commit into your git hooks:
 
 ```sh
-pre-commit install
+uv run pre-commit install
 ```
 
 ## Develop
@@ -74,38 +68,38 @@ Things that will improve the chance that your pull request will be accepted:
 
 ## Test
 
-Install the dependencies:
+If you didn't install the dependencies earlier, you can install only the test dependencies:
 
 ```sh
-pip install -e '.[test]'
+uv sync --only-group test
 ```
 
 Run the tests:
 
 ```sh
-pytest
+uv run pytest
 ```
 
 Run the tests with [coverage](https://coverage.readthedocs.io/):
 
 ```sh
-coverage run -m pytest
+uv run coverage run -m pytest
 ```
 
 Generate a coverage report:
 
 ```sh
-coverage report
+uv run coverage report
 ```
 
 ```sh
-coverage html
+uv run coverage html
 ```
 
-Install the package with [pipx](https://pipx.pypa.io/):
+Install the package with [uv](https://docs.astral.sh/uv/):
 
 ```sh
-pipx install . --force
+uv tool install . --force
 ```
 
 Test the command:
@@ -116,80 +110,80 @@ diffused --help
 
 ## Lint
 
-Install the dependencies:
+If you didn't install the dependencies earlier, you can install only the lint dependencies:
 
 ```sh
-pip install -e '.[lint]'
+uv sync --only-group lint
 ```
 
 Update pre-commit hooks to the latest version:
 
 ```sh
-pre-commit autoupdate
+uv run pre-commit autoupdate
 ```
 
 Run all pre-commit hooks:
 
 ```sh
-pre-commit run --all-files
+uv run pre-commit run --all-files
 ```
 
 Lint all files in the current directory:
 
 ```sh
-ruff check
+uv run ruff check
 ```
 
 Format all files in the current directory:
 
 ```sh
-ruff format
+uv run ruff format
 ```
 
 ## Build
 
-Install the dependencies:
+If you didn't install the dependencies earlier, you can install only the build dependencies:
 
 ```sh
-pip install -e '.[build]'
+uv sync --only-group build
 ```
 
 Generate the distribution packages:
 
 ```sh
-python3 -m build
+uv build
 ```
 
-Upload all of the archives under `dist`:
+Upload all of the archives under `dist` to TestPyPI:
 
 ```sh
-twine upload --repository testpypi dist/*
+uv publish --publish-url https://test.pypi.org/legacy/
 ```
 
 Install the package:
 
 ```sh
-pip install --index-url https://test.pypi.org/simple/ --no-deps diffused
+uv tool install diffused --index-url https://test.pypi.org/simple/
 ```
 
 Bundle the package with [PyInstaller](https://pyinstaller.org/):
 
 ```sh
-pyinstaller src/diffused/cli.py --name diffused
+uv run pyinstaller src/diffused/cli.py --name diffused
 ```
 
 ## Docs
 
-Install the dependencies:
+If you didn't install the dependencies earlier, you can install only the docs dependencies:
 
 ```sh
-pip install -e '.[docs]'
+uv sync --only-group docs
 ```
 
 Generate the docs with [pdoc](https://pdoc.dev/):
 
 ```sh
-pdoc src/diffused/
+uv run pdoc src/diffused/
 ```
 
 ## Release

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,19 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
-      - name: Use Python
-        uses: actions/setup-python@v6
-        with:
-          cache: pip
-          python-version-file: pyproject.toml
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8
 
       - name: Install dependencies
-        run: pip install -e .[docs]
+        run: uv sync --only-group docs
 
       - name: Build docs
-        run: pdoc src/diffused/ -o docs
+        run: uv run pdoc src/diffused/ -o docs
 
       - name: Deploy
         if: github.ref_name == 'master'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.3.2
 
       - name: Install dependencies
         run: uv sync --only-group docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.3.2
 
       - name: Install dependencies
         run: uv sync --only-group lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,22 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
-      - name: Use Python
-        uses: actions/setup-python@v6
-        with:
-          cache: pip
-          python-version-file: pyproject.toml
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8
 
       - name: Install dependencies
-        run: pip install -e .[lint]
-
-      - name: Run Black
-        run: black --check .
-
-      - name: Run Ruff
-        run: ruff check
+        run: uv sync --only-group lint
 
       - name: Run pre-commit
-        run: pre-commit run --all-files
+        run: uv run pre-commit run --all-files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.3.2
 
       - name: Build package
         run: uv build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Release Please
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         id: release
         with:
           release-type: python
@@ -34,18 +34,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
-      - name: Use Python
-        uses: actions/setup-python@v6
-        with:
-          python-version-file: pyproject.toml
-
-      - name: Install build
-        run: python -m pip install build
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8
 
       - name: Build package
-        run: python -m build
+        run: uv build
 
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.14.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,25 +9,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
-      - name: Use Python
-        uses: actions/setup-python@v6
-        with:
-          cache: pip
-          python-version-file: pyproject.toml
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8
 
       - name: Install dependencies
-        run: pip install -e .[test]
+        run: uv sync --only-group test
 
       - name: Run tests and collect coverage
         run: |
-          coverage run -m pytest
-          coverage report
-          coverage xml
+          uv run coverage run -m pytest
+          uv run coverage report
+          uv run coverage xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -35,16 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
-      - name: Use Python
-        uses: actions/setup-python@v6
-        with:
-          cache: pip
-          python-version-file: pyproject.toml
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8
 
       - name: Install package
-        run: pipx install .
+        run: uv tool install .
 
       - name: Check version
         run: |
@@ -78,22 +72,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cache models
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cache/huggingface/
           key: ${{ runner.os }}-huggingface
 
-      - name: Use Python
-        uses: actions/setup-python@v6
-        with:
-          cache: pip
-          python-version-file: pyproject.toml
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8
 
       - name: Install package
-        run: pipx install .
+        run: uv tool install .
 
       - name: Generate image
         run: diffused segmind/tiny-sd ${{ matrix.test.args }}
@@ -101,7 +92,7 @@ jobs:
           DO_NOT_TRACK: 1
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.test.task }}-${{ hashFiles('**/*.jpg', '**/*.png') }}
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.3.2
 
       - name: Install dependencies
         run: uv sync --only-group test
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.3.2
 
       - name: Install package
         run: uv tool install .
@@ -81,7 +81,7 @@ jobs:
           key: ${{ runner.os }}-huggingface
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.3.2
 
       - name: Install package
         run: uv tool install .

--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ ipython_config.py
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
-#uv.lock
+uv.lock
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -16,18 +16,18 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.5.1
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/isort
-    rev: 6.0.1
+    rev: 8.0.1
     hooks:
       - id: isort
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.2
+    rev: v0.15.21
     hooks:
       - id: ruff
-        args: [ --fix ]
+        args: [--fix]
       - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -15,29 +15,41 @@ diffused <model> <prompt>
 [Text-to-image](https://huggingface.co/docs/diffusers/using-diffusers/conditional_image_generation):
 
 ```sh
+uv run --with diffused diffused segmind/tiny-sd "red apple"
+```
+
+Or with [pipx](https://pipx.pypa.io/):
+
+```sh
 pipx run diffused segmind/tiny-sd "red apple"
 ```
 
 [Image-to-image](https://huggingface.co/docs/diffusers/using-diffusers/img2img):
 
 ```sh
-pipx run diffused OFA-Sys/small-stable-diffusion-v0 "cat wizard" --image=https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/cat.png
+uv run --with diffused diffused OFA-Sys/small-stable-diffusion-v0 "cat wizard" --image=https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/cat.png
 ```
 
 [Inpainting](https://huggingface.co/docs/diffusers/en/using-diffusers/inpaint):
 
 ```sh
-pipx run diffused kandinsky-community/kandinsky-2-2-decoder-inpaint "black cat" --image=https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint.png --mask-image=https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint_mask.png
+uv run --with diffused diffused kandinsky-community/kandinsky-2-2-decoder-inpaint "black cat" --image=https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint.png --mask-image=https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint_mask.png
 ```
 
 ## Prerequisites
 
 - [Python](https://www.python.org/)
-- [pipx](https://pipx.pypa.io/)
+- [uv](https://docs.astral.sh/uv/) or [pipx](https://pipx.pypa.io/)
 
 ## CLI
 
-Install the CLI:
+Install the CLI with [uv](https://docs.astral.sh/uv/):
+
+```sh
+uv tool install diffused
+```
+
+Or with [pipx](https://pipx.pypa.io/):
 
 ```sh
 pipx install diffused
@@ -45,7 +57,7 @@ pipx install diffused
 
 ### `model`
 
-**Required** (*str*): The diffusion [model](https://huggingface.co/models).
+**Required** (_str_): The diffusion [model](https://huggingface.co/models).
 
 ```sh
 diffused segmind/SSD-1B "An astronaut riding a green horse"
@@ -55,7 +67,7 @@ See [segmind/SSD-1B](https://huggingface.co/segmind/SSD-1B).
 
 ### `prompt`
 
-**Required** (*str*): The text prompt.
+**Required** (_str_): The text prompt.
 
 ```sh
 diffused dreamlike-art/dreamlike-photoreal-2.0 "cinematic photo of Godzilla eating sushi with a cat in a izakaya, 35mm photograph, film, professional, 4k, highly detailed"
@@ -63,7 +75,7 @@ diffused dreamlike-art/dreamlike-photoreal-2.0 "cinematic photo of Godzilla eati
 
 ### `--negative-prompt`
 
-**Optional** (*str*): What to exclude from the output image.
+**Optional** (_str_): What to exclude from the output image.
 
 ```sh
 diffused stabilityai/stable-diffusion-2 "photo of an apple" --negative-prompt="blurry, bright photo, red"
@@ -77,7 +89,7 @@ diffused stabilityai/stable-diffusion-2 "photo of an apple" -np="blurry, bright 
 
 ### `--image`
 
-**Optional** (*str*): The input image path or URL. The initial image is used as a starting point for an [image-to-image](https://huggingface.co/docs/diffusers/using-diffusers/img2img) diffusion process.
+**Optional** (_str_): The input image path or URL. The initial image is used as a starting point for an [image-to-image](https://huggingface.co/docs/diffusers/using-diffusers/img2img) diffusion process.
 
 ```sh
 diffused stabilityai/stable-diffusion-xl-refiner-1.0 "astronaut in a desert" --image=https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/img2img-init.png
@@ -91,7 +103,7 @@ diffused stabilityai/stable-diffusion-xl-refiner-1.0 "astronaut in a desert" -i=
 
 ### `--mask-image`
 
-**Optional** (*str*): The mask image path or URL. [Inpainting](https://huggingface.co/docs/diffusers/en/using-diffusers/inpaint) replaces or edits specific areas of an image. [Create a mask image](https://huggingface.co/docs/diffusers/en/using-diffusers/inpaint#create-a-mask-image) to inpaint images.
+**Optional** (_str_): The mask image path or URL. [Inpainting](https://huggingface.co/docs/diffusers/en/using-diffusers/inpaint) replaces or edits specific areas of an image. [Create a mask image](https://huggingface.co/docs/diffusers/en/using-diffusers/inpaint#create-a-mask-image) to inpaint images.
 
 ```sh
 diffused kandinsky-community/kandinsky-2-2-decoder-inpaint "black cat" --image=https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint.png --mask-image=https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint_mask.png
@@ -105,7 +117,7 @@ diffused kandinsky-community/kandinsky-2-2-decoder-inpaint "black cat" -i=inpain
 
 ### `--output`
 
-**Optional** (*str*): The output image filename.
+**Optional** (_str_): The output image filename.
 
 ```sh
 diffused dreamlike-art/dreamlike-photoreal-2.0 "cat eating sushi" --output=cat.jpg
@@ -119,7 +131,7 @@ diffused dreamlike-art/dreamlike-photoreal-2.0 "cat eating sushi" -o=cat.jpg
 
 ### `--width`
 
-**Optional** (*int*): The output image width in pixels.
+**Optional** (_int_): The output image width in pixels.
 
 ```sh
 diffused stabilityai/stable-diffusion-xl-base-1.0 "dog in space" --width=1024
@@ -133,7 +145,7 @@ diffused stabilityai/stable-diffusion-xl-base-1.0 "dog in space" -W=1024
 
 ### `--height`
 
-**Optional** (*int*): The output image height in pixels.
+**Optional** (_int_): The output image height in pixels.
 
 ```sh
 diffused stabilityai/stable-diffusion-xl-base-1.0 "dog in space" --height=1024
@@ -147,7 +159,7 @@ diffused stabilityai/stable-diffusion-xl-base-1.0 "dog in space" -H=1024
 
 ### `--number`
 
-**Optional** (*int*): The number of output images. Defaults to 1.
+**Optional** (_int_): The number of output images. Defaults to 1.
 
 ```sh
 diffused segmind/tiny-sd apple --number=2
@@ -161,7 +173,7 @@ diffused segmind/tiny-sd apple -n=2
 
 ### `--guidance-scale`
 
-**Optional** (*int*): How much the prompt influences the output image. A lower value leads to more deviation and creativity, whereas a higher value follows the prompt to a tee.
+**Optional** (_int_): How much the prompt influences the output image. A lower value leads to more deviation and creativity, whereas a higher value follows the prompt to a tee.
 
 ```sh
 diffused stable-diffusion-v1-5/stable-diffusion-v1-5 "astronaut in a jungle" --guidance-scale=7.5
@@ -175,7 +187,7 @@ diffused stable-diffusion-v1-5/stable-diffusion-v1-5 "astronaut in a jungle" -gs
 
 ### `--inference-steps`
 
-**Optional** (*int*): The number of diffusion steps used during image generation. The more steps you use, the higher the quality, but the generation time will increase.
+**Optional** (_int_): The number of diffusion steps used during image generation. The more steps you use, the higher the quality, but the generation time will increase.
 
 ```sh
 diffused CompVis/stable-diffusion-v1-4 "astronaut rides horse" --inference-steps=50
@@ -189,7 +201,7 @@ diffused CompVis/stable-diffusion-v1-4 "astronaut rides horse" -is=50
 
 ### `--strength`
 
-**Optional** (*float*): The noise added to the input image, which determines how much the output image deviates from the original image. Strength is used for [image-to-image](https://huggingface.co/docs/diffusers/using-diffusers/img2img#strength) and [inpainting](https://huggingface.co/docs/diffusers/using-diffusers/inpaint#strength) tasks and is a multiplier to the number of denoising steps (`--inference-steps`).
+**Optional** (_float_): The noise added to the input image, which determines how much the output image deviates from the original image. Strength is used for [image-to-image](https://huggingface.co/docs/diffusers/using-diffusers/img2img#strength) and [inpainting](https://huggingface.co/docs/diffusers/using-diffusers/inpaint#strength) tasks and is a multiplier to the number of denoising steps (`--inference-steps`).
 
 ```sh
 diffused stabilityai/stable-diffusion-xl-refiner-1.0 "astronaut in swamp" --image=https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/img2img-sdxl-init.png --strength=0.5
@@ -203,7 +215,7 @@ diffused stabilityai/stable-diffusion-xl-refiner-1.0 "astronaut in swamp" -i=ima
 
 ### `--seed`
 
-**Optional** (*int*): The seed for generating random numbers, ensuring [reproducibility](https://huggingface.co/docs/diffusers/using-diffusers/reusing_seeds) in image generation pipelines.
+**Optional** (_int_): The seed for generating random numbers, ensuring [reproducibility](https://huggingface.co/docs/diffusers/using-diffusers/reusing_seeds) in image generation pipelines.
 
 ```sh
 diffused stable-diffusion-v1-5/stable-diffusion-v1-5 "Labrador in the style of Vermeer" --seed=0
@@ -217,7 +229,7 @@ diffused stable-diffusion-v1-5/stable-diffusion-v1-5 "Labrador in the style of V
 
 ### `--device`
 
-**Optional** (*str*): The [device](https://pytorch.org/docs/stable/tensor_attributes.html#torch.device) to accelerate the computation (`cpu`, `cuda`, `mps`, `xpu`, `xla`, or `meta`).
+**Optional** (_str_): The [device](https://pytorch.org/docs/stable/tensor_attributes.html#torch.device) to accelerate the computation (`cpu`, `cuda`, `mps`, `xpu`, `xla`, or `meta`).
 
 ```sh
 diffused stable-diffusion-v1-5/stable-diffusion-v1-5 "astronaut on earth, 8k" --device=cuda
@@ -231,7 +243,7 @@ diffused stable-diffusion-v1-5/stable-diffusion-v1-5 "astronaut on earth, 8k" -d
 
 ### `--no-safetensors`
 
-**Optional** (*bool*): Whether to disable [safetensors](https://huggingface.co/docs/diffusers/main/en/using-diffusers/using_safetensors).
+**Optional** (_bool_): Whether to disable [safetensors](https://huggingface.co/docs/diffusers/main/en/using-diffusers/using_safetensors).
 
 ```sh
 diffused runwayml/stable-diffusion-v1-5 "astronaut on mars" --no-safetensors
@@ -255,22 +267,10 @@ diffused --help # diffused -h
 
 ## Script
 
-Create a virtual environment:
+Create a virtual environment and install the package with [uv](https://docs.astral.sh/uv/):
 
 ```sh
-python3 -m venv .venv
-```
-
-Activate the virtual environment:
-
-```sh
-source .venv/bin/activate
-```
-
-Install the package:
-
-```sh
-pip install diffused
+uv add diffused
 ```
 
 Generate an image with a [model](https://huggingface.co/segmind/tiny-sd) and a prompt:
@@ -286,7 +286,7 @@ images[0].save("apple.png")
 Run the script:
 
 ```sh
-python script.py
+uv run python script.py
 ```
 
 Open the image:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,12 +2,12 @@
 name = "diffused"
 version = "1.0.1"
 description = "Generate images with diffusion models."
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
-    "accelerate>=1.5.0",
-    "diffusers>=0.32.0",
-    "torch>=2.6.0",
-    "transformers>=4.50.0",
+    "accelerate>=1.14.0",
+    "diffusers>=0.39.0",
+    "torch>=2.13.0",
+    "transformers>=5.14.0",
 ]
 authors = [
     { name="Mark", email="mark@remarkablemark.org" },
@@ -47,24 +47,23 @@ diffused = "diffused.cli:main"
 [project.entry-points."pipx.run"]
 diffused = "diffused.cli:main"
 
-[project.optional-dependencies]
+[dependency-groups]
 build = [
-    "build==1.4.0",
-    "pyinstaller==6.18.0",
-    "twine==6.2.0",
+    "build==1.5.0",
+    "pyinstaller==6.21.0",
 ]
 docs = [
     "pdoc==16.0.0",
 ]
 lint = [
-    "black==25.12.0",
-    "isort==7.0.0",
-    "pre-commit==4.5.1",
-    "ruff==0.14.13",
+    "black==26.5.1",
+    "isort==8.0.1",
+    "pre-commit==4.6.0",
+    "ruff==0.15.21",
 ]
 test = [
-    "coverage==7.13.1",
-    "pytest==9.0.2",
+    "coverage==7.15.2",
+    "pytest==9.1.1",
 ]
 
 [project.urls]
@@ -82,3 +81,10 @@ omit = [
     # omit pytorch-generated files in /tmp
     "/tmp/*",
 ]
+
+[build-system]
+requires = ["setuptools>=75.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/diffused/generate.py
+++ b/src/diffused/generate.py
@@ -78,7 +78,10 @@ def generate(**kwargs: Unpack[Generate]) -> list[Image.Image]:
         )
         Pipeline = diffusers.AutoPipelineForInpainting
 
-    pipeline = Pipeline.from_pretrained(kwargs.get("model"))
+    pipeline = Pipeline.from_pretrained(
+        kwargs.get("model"),
+        torch_dtype=torch.float32,
+    )
 
     device = kwargs.get("device")
     if device:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,5 @@
 import re
-from unittest.mock import Mock, call, patch
+from unittest.mock import ANY, Mock, call, patch
 
 import pytest
 
@@ -59,7 +59,7 @@ def test_generate_image(
 ) -> None:
     Pipeline.reset_mock()
     main([model, prompt])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     Pipeline.mock.assert_called_once_with(
         prompt=prompt,
         negative_prompt=None,
@@ -84,7 +84,7 @@ def test_generate_image(
 def test_output(mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "--output", image])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     assert len(Pipeline.images) == 1
     Pipeline.images[0].save.assert_called_once_with(image)
     captured = capsys.readouterr()
@@ -97,7 +97,7 @@ def test_output_short(
 ) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "-o", image])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     captured = capsys.readouterr()
     assert captured.out == f"🤗 {image}\n"
 
@@ -106,7 +106,7 @@ def test_output_short(
 def test_number(mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "-o", "test.jpg", "-n", "2"])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     assert len(Pipeline.images) == 2
     captured = capsys.readouterr()
     assert captured.out == "🤗 test1.jpg\n🤗 test2.jpg\n"
@@ -118,7 +118,7 @@ def test_number_short(
 ) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "-o", "test.jpg", "-n", "10"])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     captured = capsys.readouterr()
     assert len(Pipeline.images) == 10
     for img in Pipeline.images:
@@ -133,7 +133,7 @@ def test_width_height(
 ) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "--width", "1024", "--height", "1024"])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
@@ -144,7 +144,7 @@ def test_width_height_short(
 ) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "-W", "1024", "-H", "1024"])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
@@ -153,7 +153,7 @@ def test_width_height_short(
 def test_device(mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "--device", device])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     Pipeline.to.assert_called_once_with(device)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
@@ -165,7 +165,7 @@ def test_device_short(
 ) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "-d", "cpu"])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     Pipeline.to.assert_called_once_with("cpu")
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
@@ -177,7 +177,7 @@ def test_negative_prompt(
 ) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "--negative-prompt", "blurry"])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
@@ -188,7 +188,7 @@ def test_negative_prompt_short(
 ) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "-np", "blurry"])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
@@ -199,7 +199,7 @@ def test_guidance_scale(
 ) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "--guidance-scale", "7.5"])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
@@ -210,7 +210,7 @@ def test_guidance_scale_short(
 ) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "-gs", "7.5"])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
@@ -221,7 +221,7 @@ def test_inference_steps(
 ) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "--inference-steps", "50"])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
@@ -232,7 +232,7 @@ def test_inference_steps_short(
 ) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "-is", "15"])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
@@ -241,7 +241,7 @@ def test_inference_steps_short(
 def test_strength(mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "--strength", "0.5"])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
@@ -252,7 +252,7 @@ def test_strength_short(
 ) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "-s", "0.5"])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
@@ -261,7 +261,7 @@ def test_strength_short(
 def test_seed(mock_from_pretrained: Mock, capsys: pytest.LogCaptureFixture) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "--seed", "0"])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
@@ -272,7 +272,7 @@ def test_seed_short(
 ) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "-S", "-1"])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
@@ -283,7 +283,7 @@ def test_safetensors(
 ) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "--safetensors"])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
@@ -294,7 +294,7 @@ def test_no_safetensors(
 ) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "--no-safetensors"])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
 
@@ -306,7 +306,7 @@ def test_image(
 ) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "--image", image])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     mock_load_image.assert_called_once_with(image)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
@@ -319,7 +319,7 @@ def test_image_short(
 ) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "-i", image])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     mock_load_image.assert_called_once_with(image)
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
@@ -332,7 +332,7 @@ def test_mask_image(
 ) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "--image", image, "--mask-image", mask_image])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     mock_load_image.assert_has_calls([call(image), call(mask_image)])
     captured = capsys.readouterr()
     assert "🤗 " in captured.out
@@ -345,7 +345,7 @@ def test_mask_image_short(
 ) -> None:
     Pipeline.reset_mock()
     main([model, prompt, "-i", image, "-mi", mask_image])
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     mock_load_image.assert_has_calls([call(image), call(mask_image)])
     captured = capsys.readouterr()
     assert "🤗 " in captured.out

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -19,7 +19,7 @@ def test_text_to_image(mock_from_pretrained: Mock) -> None:
     images = generate(model=model, prompt=prompt)
     assert len(images) == 1
     assert isinstance(images[0], Mock)
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     Pipeline.mock.assert_called_once_with(**pipeline_args)
     Pipeline.to.assert_not_called()
 
@@ -41,7 +41,7 @@ def test_text_to_image_with_arguments(mock_from_pretrained: Mock) -> None:
     images = generate(model=model, device=device, **pipeline_args)
     assert len(images) == 2
     assert isinstance(images[0], Mock)
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     Pipeline.mock.assert_called_once_with(**pipeline_args)
     Pipeline.to.assert_called_once_with(device)
 
@@ -64,7 +64,7 @@ def test_text_to_image_with_seed(
     images = generate(model=model, device=device, seed=seed, **pipeline_args)
     assert len(images) == 1
     assert isinstance(images[0], Mock)
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     mock_generator.assert_called_once_with(device=device)
     pipeline_args["generator"] = ANY
     Pipeline.mock.assert_called_once_with(**pipeline_args)
@@ -92,7 +92,7 @@ def test_arguments_with_zero_values(
     images = generate(model=model, seed=seed, **pipeline_args)
     assert len(images) == 1
     assert isinstance(images[0], Mock)
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     mock_generator.assert_called_once_with(device=None)
     pipeline_args["generator"] = ANY
     Pipeline.mock.assert_called_once_with(**pipeline_args)
@@ -116,7 +116,7 @@ def test_image_to_image(mock_from_pretrained: Mock, mock_load_image: Mock) -> No
     images = generate(model=model, prompt=prompt, image=image)
     assert len(images) == 1
     assert isinstance(images[0], Mock)
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     mock_load_image.assert_called_once_with(image)
     Pipeline.mock.assert_called_once_with(**pipeline_args)
     Pipeline.to.assert_not_called()
@@ -140,7 +140,7 @@ def test_inpainting(mock_from_pretrained: Mock, mock_load_image: Mock) -> None:
     images = generate(model=model, prompt=prompt, image=image, mask_image=mask_image)
     assert len(images) == 1
     assert isinstance(images[0], Mock)
-    mock_from_pretrained.assert_called_once_with(model)
+    mock_from_pretrained.assert_called_once_with(model, torch_dtype=ANY)
     mock_load_image.assert_has_calls([call(image), call(mask_image)])
     Pipeline.mock.assert_called_once_with(**pipeline_args)
     Pipeline.to.assert_not_called()


### PR DESCRIPTION
## What is the motivation for this pull request?

Migrate the project from pip/pipx to uv for dependency management, CI, and local development. uv provides faster installs, a unified lock file, and built-in publishing/tool support.

[plan.md](https://github.com/user-attachments/files/30071178/plan.md)

## What is the current behavior?

- Local development and CI use `pip`, `pipx`, and `actions/setup-python`.
- Development dependencies are declared as `[project.optional-dependencies]` extras (`build`, `docs`, `lint`, `test`).
- There is no committed build backend in `pyproject.toml`.

## What is the new behavior?

- CI workflows use `astral-sh/setup-uv` and run commands with `uv run`/`uv sync`/`uv build`/`uv tool install`.
- Development dependencies are moved to PEP 735 `[dependency-groups]`.
- A `[build-system]` section is added to `pyproject.toml`.
- All dependencies, GitHub Actions, and pre-commit hooks are bumped to their latest stable versions.
- `uv.lock` is generated locally but ignored in version control.
- README and CONTRIBUTING documentation now use uv instructions (pipx remains as an alternative in README).

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation
